### PR TITLE
persist regenerated config tokens

### DIFF
--- a/src/splatnet3_scraper/query/config/config.py
+++ b/src/splatnet3_scraper/query/config/config.py
@@ -108,6 +108,8 @@ class Config:
                 token,
                 self.token_manager.get_token(token).value,
             )
+        if self._output_file_path is not None:
+            self.save_to_file()
 
     @property
     def session_token(self) -> str:

--- a/tests/query/configuration/test_config.py
+++ b/tests/query/configuration/test_config.py
@@ -48,6 +48,32 @@ class TestConfig:
         mock_token_manager.regenerate_tokens.assert_called_once_with()
         assert mock_handler.set_value.call_count == 3
 
+    def test_regenerate_tokens_saves_file_backed_config(self) -> None:
+        mock_token_manager = MagicMock()
+        mock_handler = MagicMock()
+        config = Config(
+            mock_handler,
+            token_manager=mock_token_manager,
+            output_file_path="test.ini",
+        )
+        config.save_to_file = MagicMock()
+
+        config.regenerate_tokens()
+
+        mock_token_manager.regenerate_tokens.assert_called_once_with()
+        assert mock_handler.set_value.call_count == 3
+        config.save_to_file.assert_called_once_with()
+
+    def test_regenerate_tokens_does_not_save_without_file_path(self) -> None:
+        mock_token_manager = MagicMock()
+        mock_handler = MagicMock()
+        config = Config(mock_handler, token_manager=mock_token_manager)
+        config.save_to_file = MagicMock()
+
+        config.regenerate_tokens()
+
+        config.save_to_file.assert_not_called()
+
     @pytest.mark.parametrize(
         "token",
         [


### PR DESCRIPTION
## Summary
- auto-save regenerated tokens when a `Config` instance is backed by a file path
- keep in-memory-only configs unchanged
- add focused tests covering both behaviors

## Why
A successful live token regeneration currently updates the in-memory config but does not persist `gtoken` and `bullet_token` back to disk unless callers remember to invoke `save_to_file()` separately. That makes expensive successful refreshes easy to lose.

## Impact
File-backed uses of `Config.regenerate_tokens()` now persist refreshed tokens immediately after a successful regeneration. This keeps `.splatnet3_scraper` aligned with the live token state without changing memory-only callers.

## Testing
- `uv run pytest -q tests/query/configuration/test_config.py tests/query/test_queryhandler.py`
